### PR TITLE
Fix: Specify the visibility of the package as "public"

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -2,7 +2,7 @@ name: Publish to NPM
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - "v[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   publish:
@@ -16,6 +16,6 @@ jobs:
         with:
           node-version: "18.x"
           registry-url: "https://registry.npmjs.org/"
-      - run: npm publish
+      - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Description

A scoped npm package, which is named like "@xxx/...", automatically becomes a private package. In order to make it public, the publishing command has to include the "--access public" option.

Thus the publishing command should looks like:
```
npm publish --access public
```